### PR TITLE
Solved Problem with 'missing default export' error

### DIFF
--- a/bounceable.js
+++ b/bounceable.js
@@ -5,7 +5,7 @@ import {Animated, PanResponder, View} from "react-native";
 
 const moveTolerance = 30; // Amount of movement before it is no longer a press
 
-class Bounceable extends Component {
+export default class Bounceable extends Component {
   static propTypes = {
     onPress: React.PropTypes.func, //Optional function to be excecuted after succesful press
     level: React.PropTypes.number // Maximum scale of animation
@@ -90,5 +90,3 @@ class Bounceable extends Component {
     );
   }
 }
-
-module.exports = Bounceable;


### PR DESCRIPTION
This change solves 'Missing default export' error. I simply added a _export default_  before the class Component. Obviously I removed previous _module.exports = Bounceable;_